### PR TITLE
Lock the version of dependency jkroso/type to the 1.1 branch

### DIFF
--- a/component.json
+++ b/component.json
@@ -12,7 +12,7 @@
     "equals"
   ],
   "dependencies": {
-    "jkroso/type": "*"
+    "jkroso/type": "^1.1.0"
   },
   "scripts": ["index.js"],
   "license": "MIT"


### PR DESCRIPTION
The component/assert module has a dependency on jkroso/equals "*" (see https://github.com/component/assert/blob/master/component.json) which in turn has a dependency on jkroso/type "*". Since jkroso/equals made a breaking change about a day ago - jumping from v1.1.0 to 2.0.0 in the process - the use of "*" version dependencies has broken apps using component/assert that are not yet ready for es2015.

Please produce a minor release - e.g. 1.0.2 - that locks the dependency on type to < 2.0.0