### PR TITLE
Further revert equals changes back to the equivalent of 1.0.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var type = require('@jkroso/type')
+var type = require('jkroso-type')
 
 // (any, any, [array]) -> boolean
 function equal(a, b, memos){

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "equals",
-  "version": "1.1.0",
+  "version": "1.0.5",
   "description": "Check if two values are deeply equivalent",
   "dependencies": {
-    "@jkroso/type": "1"
+    "jkroso-type": "1"
   },
   "devDependencies": {
     "serve": "jkroso/serve",


### PR DESCRIPTION
It took a little while for component/assert to merge the v1 backwards compatible changes (https://github.com/component/assert/pull/19) but after extensive testing it appears the changes in https://github.com/jkroso/equals/pull/9 did not revert the changes does to the equals module back far enough.

Please merge the changes in this pull request and publish a new 1.0.x version of equals.

Many thanks
